### PR TITLE
Added support for norg and vimwiki filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mdeval.nvim
 
-This plugin allows you evaluate code blocks inside markdown documents.
+This plugin allows you evaluate code blocks inside markdown,vimwiki and norg documents.
 
 It attempts to implement the basic functionality of org-mode's [evaluating code blocks](https://orgmode.org/manual/Evaluating-Code-Blocks.html#Evaluating-Code-Blocks) feature inside Neovim.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mdeval.nvim
 
-This plugin allows you evaluate code blocks inside markdown,vimwiki and norg documents.
+This plugin allows you evaluate code blocks inside markdown, [vimwiki](https://github.com/vimwiki/vimwiki) and [norg](https://github.com/vhyrro/neorg) documents.
 
 It attempts to implement the basic functionality of org-mode's [evaluating code blocks](https://orgmode.org/manual/Evaluating-Code-Blocks.html#Evaluating-Code-Blocks) feature inside Neovim.
 

--- a/lua/defaults.lua
+++ b/lua/defaults.lua
@@ -1,4 +1,11 @@
 local M = {}
+local lang_conf = {}
+
+lang_conf["markdown"] = {"```", "```"}
+lang_conf["vimwiki"] = {"{{{", "}}}"}
+lang_conf["norg"] = {"@code", "@end"}
+
+M.lang_conf = lang_conf
 
 M.require_confirmation = true
 M.allowed_file_types = {}


### PR DESCRIPTION
I am looking into neorg and I would to use it for note taking for now, it don't provides code block execution
so I modified *mdeval* to support norg file and while i was at it, i also added support for vimwiki codeblocks 
and ability to easily add any other custom fileformat . can you please merge these changes
