### PR TITLE
Use plain string matching

### DIFF
--- a/lua/mdeval.lua
+++ b/lua/mdeval.lua
@@ -287,7 +287,7 @@ end
 -- Parses start line to get code of the language.
 -- For example: `#+BEGIN_SRC cpp` returns `cpp`.
 local function get_lang(start_line)
-  local start_pos = string.find(start_line, code_block_start())
+  local start_pos = string.find(start_line, code_block_start(), 1, true)
   local len = string.len(code_block_start())
   return string.sub(start_line, start_pos + len):gsub("%s+", "")
 end


### PR DESCRIPTION
Hey, first of all thanks for making this plugin!

This is just a simple PR to fix a bug with Org files, by using plain matching instead of regex.

`eval_code_block` fails to parse the language specifier in Org files due to `string.find` using regex matching by default. `#+BEGIN_SRC` will be interpreted as a regex and thus fail to match "#+" literally.