### PR TITLE
feat: allows showing output as virtual text

### DIFF
--- a/lua/defaults.lua
+++ b/lua/defaults.lua
@@ -9,6 +9,7 @@ lang_conf["markdown.pandoc"] = { "```", "```" }
 
 M.lang_conf = lang_conf
 
+M.virtual_text = false
 M.require_confirmation = true
 M.allowed_file_types = {}
 M.exec_timeout = -1


### PR DESCRIPTION
The virtual text works!

However, there is one problem:

Output should not be cleaned when the code block is run again or with `MdEvalClean`.

Let us work to get it done!