### PR TITLE
get only the first word after code_block_start in get_lang

### DIFF
--- a/lua/mdeval.lua
+++ b/lua/mdeval.lua
@@ -289,7 +289,7 @@ end
 local function get_lang(start_line)
   local start_pos = string.find(start_line, code_block_start(), 1, true)
   local len = string.len(code_block_start())
-  return string.sub(start_line, start_pos + len):gsub("%s+", "")
+  return string.sub(start_line, start_pos + len):match("%w+")
 end
 
 -- Returns indentation length for the string `s`.


### PR DESCRIPTION
Currently it gets all the text after the start of the code block without the spaces. 
Now it only get the first word so it can work in orgmode when it is followed by :tangle.

#+BEGIN_SRC c :tangle helloworld.c
#include <stdio.h>

int main(){
   printf("Hello, world!\n");
}
#+END_SRC

*Results:* `Hello, world!`