### PR TITLE
Fix nil handling for opts and opts.eval_options in mdeval.setup()

### DIFF
--- a/lua/mdeval.lua
+++ b/lua/mdeval.lua
@@ -432,18 +432,19 @@ end
 
 M.opts = defaults
 function M.setup(opts)
-  -- Apply user-defined options with fallback to defaults.
+  if not opts then
+    return
+  end
+
+  -- Apply user-defined options, skipping tables and updating eval_options.
   for k, v in pairs(opts) do
     if type(v) ~= "table" then
       M.opts[k] = v
-    end
-  end
-  for k, v in pairs(opts.eval_options) do
-    if M.opts.eval_options[k] == nil then
-      M.opts.eval_options[k] = {}
-    end
-    for nk, nv in pairs(v) do
-      M.opts.eval_options[k][nk] = nv
+    elseif k == "eval_options" then
+      M.opts.eval_options = M.opts.eval_options or {}
+      for nk, nv in pairs(v) do
+        M.opts.eval_options[nk] = nv
+      end
     end
   end
 end


### PR DESCRIPTION
The following error has been identified:

- When running `require 'mdeval'.setup()`, the value of `opts` becomes `nil`, causing an error. The same issue occurs with `opts.eval_options`.

![image](https://github.com/user-attachments/assets/d74a013e-a42e-4c1a-8f2f-fc906f264879)

To address this, the following fixes have been applied in this MR:

- Modified the code to prevent errors when `opts` is `nil` or empty.
- Modified the code to prevent errors when `opts.eval_options` is `nil` or empty.