### PR TITLE
fix(org): handle lowercase source block markers

### DIFF
--- a/lua/mdeval.lua
+++ b/lua/mdeval.lua
@@ -287,7 +287,8 @@ end
 -- Parses start line to get code of the language.
 -- For example: `#+BEGIN_SRC cpp` returns `cpp`.
 local function get_lang(start_line)
-  local start_pos = string.find(start_line, code_block_start(), 1, true)
+  local start_pos =
+    string.find(start_line:upper(), code_block_start():upper(), 1, true)
   local len = string.len(code_block_start())
   return string.sub(start_line, start_pos + len):match("%w+")
 end


### PR DESCRIPTION
## Summary
- Make org source block language detection case-insensitive.
- Prevent lowercase `#+begin_src` markers from crashing with arithmetic on nil in `get_lang`.

## Testing
- Not run; single Lua string-matching fix.